### PR TITLE
Respect DNP flag

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
 *.pyc
 pcm/build/
+.DS_Store

--- a/src/push_thread.py
+++ b/src/push_thread.py
@@ -108,7 +108,11 @@ class PushThread(Thread):
             attrs = f.GetAttributes()
             parsed_attrs = self.parse_attrs(attrs)
 
-            mount_type = 'smt' if parsed_attrs['smd'] else 'tht'  # Note: if not smd nor tht its 'other'. Consider other as tht.
+            # Ignore logos and mounting holes
+            if parsed_attrs['not_in_bom']:
+                continue
+
+            mount_type = 'smt' if parsed_attrs['smd'] else 'tht'  # If not smd nor tht it iss 'other'. Consider other as tht.
             placed = not parsed_attrs['do_not_place']
 
             components.append({

--- a/src/push_thread.py
+++ b/src/push_thread.py
@@ -109,7 +109,7 @@ class PushThread(Thread):
             parsed_attrs = self.parse_attrs(attrs)
 
             mount_type = 'smt' if parsed_attrs['smd'] else 'tht'  # Note: if not smd nor tht its 'other'. Consider other as tht.
-            placed = not parsed_attrs['not_in_bom']
+            placed = not parsed_attrs['do_not_place']
 
             components.append({
                 'pos_x': (f.GetPosition()[0] - board.GetDesignSettings().GetAuxOrigin()[0]) / 1000000.0,
@@ -122,7 +122,6 @@ class PushThread(Thread):
                 'value': f.GetValue(),
                 'mount_type': mount_type,
                 'place': placed
-
             })
 
         with open((os.path.join(temp_dir, componentsFilename)), 'w') as outfile:
@@ -209,6 +208,7 @@ class PushThread(Thread):
             'smd': self.parse_attr_flag(attrs, pcbnew.FP_SMD),
             'not_in_pos': self.parse_attr_flag(attrs, pcbnew.FP_EXCLUDE_FROM_POS_FILES),
             'not_in_bom': self.parse_attr_flag(attrs, pcbnew.FP_EXCLUDE_FROM_BOM),
-            'not_in_plan': self.parse_attr_flag(attrs, pcbnew.FP_BOARD_ONLY)
+            'not_in_plan': self.parse_attr_flag(attrs, pcbnew.FP_BOARD_ONLY),
+            'do_not_place': self.parse_attr_flag(attrs, pcbnew.FP_DNP)
         }
 


### PR DESCRIPTION
So far, we treated the `Exclude from BOM` flag as synonym for do not place. This approach was the only way in the past. Since KiCad 8, we have an additional `Do Not Place` flag. With this MR, we respect it for automatically marking parts as excluded in the AISLER project BOM. Parts that are marked as excluded from BOM in the KiCad project are now ignored.