### PR TITLE
Restore compatibility to KiCAD 9

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -30,7 +30,8 @@
     {
       "version": "0.2.7",
       "status": "stable",
-      "kicad_version": "10.00"
+      "kicad_version": "9.00",
+      "kicad_version_max": "10.00"
     }
   ]
 }

--- a/src/push_thread.py
+++ b/src/push_thread.py
@@ -89,9 +89,19 @@ class PushThread(Thread):
         # # Export component list
         self.report(30)
         components = []
-        footprints = list(board.GetFootprints())
+        if hasattr(board, 'GetModules'):
+            # KiCAD < 10.0
+            footprints = list(board.GetModules())
+        else:
+            # KiCAD >= 10.0
+            footprints = list(board.GetFootprints())
         for i, f in enumerate(footprints):
-            footprint_name = str(f.GetFPID().GetLibItemName())
+            try:
+                # KiCAD < 10.0
+                footprint_name = str(f.GetFPID().GetFootprintName())
+            except AttributeError:
+                # KiCAD >= 10.0
+                footprint_name = str(f.GetFPID().GetLibItemName())
 
             layer = {
                 pcbnew.F_Cu: 'top',
@@ -215,7 +225,11 @@ class PushThread(Thread):
     def getMpnFromFootprint(self, f):
         keys = ['mpn', 'MPN', 'Mpn', 'AISLER_MPN']
         for key in keys:
+            if f.HasFieldByName(key):
+                # KiCAD < 10.0
+                return f.GetFieldByName(key).GetText()
             if f.HasField(key):
+                # KiCAD >= 10.0
                 return f.GetField(key).GetText()
 
     def exportODB(self, board, outputFilename, compression):


### PR DESCRIPTION
This PR restores compatibility to KiCAD 9.x while allowing install on KiCAD 10.x

This is achieved by:
- Setting `kicad_version` to 9 **AND** setting `kicad_version_max` to 10 in metadata.json
- Reverting recent API-related changes that were made between 0.2.6 and 0.3.0

### Reasoning

KiCAD 10 is very new and many users might still stick to 9. E.g.: I am on Fedora 42, and they still provide kicad-9 there. On Fedora 43, kicad-10 is in testing right now.

Note: This PR is in draft mode, because I did not yet test it fully.